### PR TITLE
Use custom textarea instead the default one

### DIFF
--- a/app/templates/edit_book.html
+++ b/app/templates/edit_book.html
@@ -38,7 +38,10 @@
                 <p>{{ form.book_rating.label }} {{ form.book_rating(value=book.rating) }}</p>
                 <p>{{ form.book_isbn.label }} {{ form.book_isbn(value=book.isbn) }}</p>
                 <!--<p>{{ form.book_tags.label }} {{ form.book_tags(value=book.tags) }}</p>-->
-                <p>{{ form.book_review.label }} (soporta <a href="https://www.markdownguide.org/basic-syntax/">markdown</a>){{ form.book_review(value=book.review, class_='wide-textarea', rows=10) }}</p>
+                <p>{{ form.book_review.label }} (soporta <a href="https://www.markdownguide.org/basic-syntax/">markdown</a>)
+                    <br>
+                    <textarea class="form-control" name="{{ form.book_review.name }}" id="{{ form.book_review.id }}" type="text" rows="15">{{ book.review }}</textarea>
+                </p>
                 {{ form.submit }}
             </form>
         </div>


### PR DESCRIPTION
With this, if the book already has a review, it will be automatically filled when going to `/edit_book/<id>`:

![Screenshot from 2023-12-20 06-13-49](https://github.com/boris/reimagined-invention/assets/537305/369de3ce-4245-49e3-9780-f26af3213b0f)

Fixes #56 
